### PR TITLE
Align and orient Molstar flipbooks automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # RMSX and Flipbook: Simple-to-use, high-resolution mapping of molecular motions over time
 
-RMSX and Flipbook are described in our *Scientific Reports* paper, “High resolution mapping of protein motions in time and space with RMSX and Flipbook” ([DOI: 10.1038/s41598-026-39869-7](https://doi.org/10.1038/s41598-026-39869-7)). RMSX combines features of RMSD and RMSF into a simple-to-understand and simple-to-implement approach for understanding how proteins move over time. It works with simulation files from common MD simulation suites, including GROMACS, NAMD, and AMBER, and is designed to generate high-resolution, publication-ready motion maps and Flipbook visualizations with minimal setup.
-
-### Quick Start
-
-**Run in Google Colab (fastest):**
+## Start Here: [Launch RMSX + Molstar in Google Colab](https://colab.research.google.com/github/AntunesLab/rmsx/blob/main/RMSX_Molstar_Colab_Demo.ipynb)
 
 [![Open RMSX Molstar Colab Demo](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/AntunesLab/rmsx/blob/main/RMSX_Molstar_Colab_Demo.ipynb)
 
-The Colab demo runs the bundled examples and displays interactive Molstar Flipbooks directly in the notebook. No local molecular viewer is required.
+**No installation required.** Run the bundled RMSX examples and explore interactive Molstar Flipbooks directly in your browser.
 
-**Run locally:** download the [Quick Start Guide Notebook](https://github.com/AntunesLab/rmsx/raw/main/RMSX_FlipBook_Quickstart.ipynb), or clone this repository and run `pip install -e .`.
+RMSX and Flipbook are described in our *Scientific Reports* paper, “High resolution mapping of protein motions in time and space with RMSX and Flipbook” ([DOI: 10.1038/s41598-026-39869-7](https://doi.org/10.1038/s41598-026-39869-7)). RMSX combines features of RMSD and RMSF into a simple-to-understand and simple-to-implement approach for understanding how proteins move over time. It works with simulation files from common MD simulation suites, including GROMACS, NAMD, and AMBER, and is designed to generate high-resolution, publication-ready motion maps and Flipbook visualizations with minimal setup.
 
 ![RMSX and Flipbook workflow overview](RMSX_Flipbook_how_to_linkedin.gif)
+
+### Run Locally
+
+Download the [Quick Start Guide Notebook](https://github.com/AntunesLab/rmsx/raw/main/RMSX_FlipBook_Quickstart.ipynb), or clone this repository and run `pip install -e .`.
 
 ### Video Walkthrough
 

--- a/rmsx/molstar_viewer.py
+++ b/rmsx/molstar_viewer.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple, Union
 
+import numpy as np
+
 
 MOLSTAR_VERSION = "5.4.2"
 MOLSTAR_JS_URL = f"https://cdn.jsdelivr.net/npm/molstar@{MOLSTAR_VERSION}/build/viewer/molstar.js"
@@ -122,6 +124,213 @@ def _parse_float(text: str) -> Optional[float]:
     if not math.isfinite(value):
         return None
     return value
+
+
+def _pdb_orientation_coordinates(pdb_text: str) -> Tuple[List[Tuple[float, float, float]], str]:
+    ca_coordinates: List[Tuple[float, float, float]] = []
+    all_coordinates: List[Tuple[float, float, float]] = []
+
+    for line in pdb_text.splitlines():
+        if not line.startswith("ATOM"):
+            continue
+        padded = line.ljust(80)
+        if padded[16:17].strip() not in {"", "A"}:
+            continue
+        x = _parse_float(padded[30:38])
+        y = _parse_float(padded[38:46])
+        z = _parse_float(padded[46:54])
+        if x is None or y is None or z is None:
+            continue
+        coordinate = (x, y, z)
+        all_coordinates.append(coordinate)
+        if padded[12:16].strip() == "CA":
+            ca_coordinates.append(coordinate)
+
+    if len(ca_coordinates) >= 2:
+        return ca_coordinates, "alpha carbons"
+    return all_coordinates, "all atoms"
+
+
+def _dot(left: Tuple[float, float, float], right: Tuple[float, float, float]) -> float:
+    return sum(a * b for a, b in zip(left, right))
+
+
+def _cross(left: Tuple[float, float, float], right: Tuple[float, float, float]) -> Tuple[float, float, float]:
+    return (
+        left[1] * right[2] - left[2] * right[1],
+        left[2] * right[0] - left[0] * right[2],
+        left[0] * right[1] - left[1] * right[0],
+    )
+
+
+def _normalize(vector: Tuple[float, float, float]) -> Tuple[float, float, float]:
+    length = math.sqrt(_dot(vector, vector))
+    if length < 1e-12:
+        return (0.0, 0.0, 0.0)
+    return (vector[0] / length, vector[1] / length, vector[2] / length)
+
+
+def _canonical_axis_sign(
+    vector: Tuple[float, float, float],
+    hint: Optional[Tuple[float, float, float]] = None,
+) -> Tuple[float, float, float]:
+    hint_dot = _dot(vector, hint) if hint is not None else 0.0
+    if abs(hint_dot) > 1e-9:
+        return vector if hint_dot > 0 else (-vector[0], -vector[1], -vector[2])
+    largest_index = max(range(3), key=lambda index: abs(vector[index]))
+    return vector if vector[largest_index] >= 0 else (-vector[0], -vector[1], -vector[2])
+
+
+def _euler_from_rotation_matrix(matrix: List[List[float]]) -> Dict[str, float]:
+    y_angle = math.asin(max(-1.0, min(1.0, -matrix[2][0])))
+    cosine_y = math.cos(y_angle)
+    if abs(cosine_y) > 1e-8:
+        x_angle = math.atan2(matrix[2][1], matrix[2][2])
+        z_angle = math.atan2(matrix[1][0], matrix[0][0])
+    else:
+        x_angle = math.atan2(-matrix[1][2], matrix[1][1])
+        z_angle = 0.0
+
+    def degrees(value: float) -> float:
+        rounded = round(math.degrees(value), 6)
+        return 0.0 if abs(rounded) < 1e-9 else rounded
+
+    return {"x": degrees(x_angle), "y": degrees(y_angle), "z": degrees(z_angle)}
+
+
+def _automatic_orientation(pdb_text: str, scope: str = "in the first slice") -> Dict[str, Any]:
+    coordinates, selection = _pdb_orientation_coordinates(pdb_text)
+    selection_description = f"{selection} {scope}"
+    fallback_matrix = [[1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0]]
+    fallback = {
+        "rotation": {"x": 90.0, "y": 0.0, "z": 0.0},
+        "matrix": fallback_matrix,
+        "source": "fixed fallback rotation",
+        "selection": selection_description,
+    }
+    if len(coordinates) < 2:
+        return fallback
+
+    coordinate_array = np.asarray(coordinates, dtype=float)
+    centered = coordinate_array - coordinate_array.mean(axis=0)
+    eigenvalues, eigenvectors = np.linalg.eigh(centered.T @ centered)
+    order = np.argsort(eigenvalues)[::-1]
+    if eigenvalues[order[0]] < 1e-10:
+        return fallback
+
+    sequence_hint = tuple(coordinates[-1][index] - coordinates[0][index] for index in range(3))
+    major_vector = tuple(float(value) for value in eigenvectors[:, order[0]])
+    secondary_vector = tuple(float(value) for value in eigenvectors[:, order[1]])
+    major_axis = _canonical_axis_sign(_normalize(major_vector), sequence_hint)
+    secondary_axis = _canonical_axis_sign(_normalize(secondary_vector))
+    depth_axis = _normalize(_cross(major_axis, secondary_axis))
+    if _dot(depth_axis, depth_axis) < 1e-10:
+        return fallback
+    secondary_axis = _normalize(_cross(depth_axis, major_axis))
+    matrix = [list(major_axis), list(secondary_axis), list(depth_axis)]
+    rounded_matrix = [[round(value, 9) for value in row] for row in matrix]
+    return {
+        "rotation": _euler_from_rotation_matrix(matrix),
+        "matrix": rounded_matrix,
+        "source": "principal-axis orientation",
+        "selection": selection_description,
+    }
+
+
+def _ca_coordinates_by_residue(pdb_text: str) -> Dict[str, Tuple[float, float, float]]:
+    coordinates: Dict[str, Tuple[float, float, float]] = {}
+    for line in pdb_text.splitlines():
+        if not line.startswith("ATOM"):
+            continue
+        padded = line.ljust(80)
+        if padded[12:16].strip() != "CA" or padded[16:17].strip() not in {"", "A"}:
+            continue
+        x = _parse_float(padded[30:38])
+        y = _parse_float(padded[38:46])
+        z = _parse_float(padded[46:54])
+        if x is None or y is None or z is None:
+            continue
+        chain_id = padded[21:22].strip() or padded[72:76].strip()
+        residue_id = (padded[22:26].strip() + padded[26:27].strip()).strip()
+        coordinates[_residue_key(chain_id, residue_id)] = (x, y, z)
+    return coordinates
+
+
+def _rigid_fit(
+    mobile: List[Tuple[float, float, float]],
+    reference: List[Tuple[float, float, float]],
+) -> Tuple[List[List[float]], Tuple[float, float, float], Tuple[float, float, float]]:
+    mobile_array = np.asarray(mobile, dtype=float)
+    reference_array = np.asarray(reference, dtype=float)
+    mobile_center_array = mobile_array.mean(axis=0)
+    reference_center_array = reference_array.mean(axis=0)
+    covariance = (mobile_array - mobile_center_array).T @ (reference_array - reference_center_array)
+    left, _, right_transpose = np.linalg.svd(covariance)
+    rotation = right_transpose.T @ left.T
+    if np.linalg.det(rotation) < 0:
+        right_transpose[-1, :] *= -1
+        rotation = right_transpose.T @ left.T
+
+    mobile_center = tuple(float(value) for value in mobile_center_array)
+    reference_center = tuple(float(value) for value in reference_center_array)
+    return rotation.tolist(), mobile_center, reference_center
+
+
+def _transform_pdb_coordinates(
+    pdb_text: str,
+    rotation: List[List[float]],
+    mobile_center: Tuple[float, float, float],
+    reference_center: Tuple[float, float, float],
+) -> str:
+    transformed_lines: List[str] = []
+    for line in pdb_text.splitlines():
+        if not (line.startswith("ATOM") or line.startswith("HETATM")):
+            transformed_lines.append(line)
+            continue
+        padded = line.ljust(80)
+        coordinate = tuple(_parse_float(padded[start:end]) for start, end in ((30, 38), (38, 46), (46, 54)))
+        if any(value is None for value in coordinate):
+            transformed_lines.append(line)
+            continue
+        centered = tuple(float(coordinate[index]) - mobile_center[index] for index in range(3))
+        transformed = [
+            reference_center[row] + sum(rotation[row][column] * centered[column] for column in range(3))
+            for row in range(3)
+        ]
+        coordinate_text = "".join(f"{value:8.3f}" for value in transformed)
+        transformed_lines.append(f"{padded[:30]}{coordinate_text}{padded[54:]}".rstrip())
+    return "\n".join(transformed_lines) + ("\n" if pdb_text.endswith("\n") else "")
+
+
+def _align_slices_to_reference(slices: List[Dict[str, Any]]) -> Dict[str, Any]:
+    reference_coordinates = _ca_coordinates_by_residue(slices[0]["pdb"])
+    aligned_slices = 1
+    skipped_slices: List[int] = []
+
+    for slice_entry in slices[1:]:
+        mobile_coordinates = _ca_coordinates_by_residue(slice_entry["pdb"])
+        common_keys = [key for key in reference_coordinates if key in mobile_coordinates]
+        if len(common_keys) < 3:
+            skipped_slices.append(int(slice_entry["index"]))
+            continue
+        mobile = [mobile_coordinates[key] for key in common_keys]
+        reference = [reference_coordinates[key] for key in common_keys]
+        rotation, mobile_center, reference_center = _rigid_fit(mobile, reference)
+        slice_entry["pdb"] = _transform_pdb_coordinates(
+            slice_entry["pdb"],
+            rotation,
+            mobile_center,
+            reference_center,
+        )
+        aligned_slices += 1
+
+    return {
+        "mode": "rigid-body least-squares fit to the first slice",
+        "selection": "common alpha carbons",
+        "referenceSlice": int(slices[0]["index"]),
+        "alignedSlices": aligned_slices,
+        "skippedSlices": skipped_slices,
+    }
 
 
 def _residue_key(chain_id: str, residue_id: str) -> str:
@@ -392,6 +601,11 @@ def build_molstar_manifest(
     normalized_camera_mode = _normalize_camera_mode(camera_mode)
 
     slices, residues, observed_domain, summaries, chain_aliases = _read_slices_and_residues(directory_path)
+    alignment = _align_slices_to_reference(slices)
+    orientation = _automatic_orientation(
+        "\n".join(slice_entry["pdb"] for slice_entry in slices),
+        scope="across aligned slices",
+    )
     domain_min = observed_domain["min"] if min_bfactor is None else min(observed_domain["min"], float(min_bfactor))
     domain_max = observed_domain["max"] if max_bfactor is None else max(observed_domain["max"], float(max_bfactor))
     domain = {"min": domain_min, "max": domain_max}
@@ -434,12 +648,15 @@ def build_molstar_manifest(
             "delayStepMs": 50,
             "delayUrlParam": "delayMs",
         },
+        "alignmentModel": alignment,
         "rotationModel": {
-            "mode": "per-slice local coordinate transform",
+            "mode": "shared principal-axis orientation with per-slice local pivots",
             "pivot": "geometric center of each full slice before mask splitting",
             "layoutOrder": "rotate around local center, then place that center on a shared Flipbook slot anchor plus tile offset",
-            "defaultRotation": {"x": 90, "y": 0, "z": 0},
-            "defaultRotationSource": "ChimeraX Flipbook command: turn x 90",
+            "defaultRotation": orientation["rotation"],
+            "defaultRotationMatrix": orientation["matrix"],
+            "defaultRotationSource": orientation["source"],
+            "orientationSelection": orientation["selection"],
         },
         "molstarRenderStyle": {
             "preset": "clean-interactive",

--- a/tests/test_molstar_viewer.py
+++ b/tests/test_molstar_viewer.py
@@ -7,10 +7,10 @@ import rmsx.flipbook as flipbook
 from rmsx.molstar_viewer import ASSET_DIR, build_molstar_manifest
 
 
-def _atom_line(serial, atom_name, chain_id, residue_id, bfactor, x, segid=""):
+def _atom_line(serial, atom_name, chain_id, residue_id, bfactor, x, y=0.0, z=0.0, segid=""):
     return (
         f"ATOM  {serial:5d} {atom_name:^4s} ALA {chain_id:1s}{residue_id:4d}    "
-        f"{x:8.3f}{0.0:8.3f}{0.0:8.3f}{1.00:6.2f}{bfactor:6.2f}"
+        f"{x:8.3f}{y:8.3f}{z:8.3f}{1.00:6.2f}{bfactor:6.2f}"
         f"      {segid:<4s}{atom_name[0]:>2s}  \n"
     )
 
@@ -28,6 +28,64 @@ def _write_slice(path: Path, chain_id: str, bfactors, segid="") -> None:
 
 
 class TestMolstarViewer(unittest.TestCase):
+    def test_slices_are_rigidly_aligned_to_first_slice(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            reference = [(0.0, 0.0, 0.0), (2.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)]
+            mobile = [(10.0 - y, 5.0 + x, 3.0 + z) for x, y, z in reference]
+            for slice_index, coordinates in enumerate((reference, mobile), start=1):
+                lines = [
+                    _atom_line(index, "CA", "A", index, float(slice_index), x, y, z)
+                    for index, (x, y, z) in enumerate(coordinates, start=1)
+                ]
+                source_text = "".join(lines) + "END\n"
+                (tmp_path / f"slice_{slice_index}_first_frame.pdb").write_text(source_text, encoding="utf-8")
+
+            manifest = build_molstar_manifest(tmp_path)
+            aligned_lines = [
+                line for line in manifest["slices"][1]["pdb"].splitlines() if line.startswith("ATOM")
+            ]
+            aligned = [
+                (float(line[30:38]), float(line[38:46]), float(line[46:54]))
+                for line in aligned_lines
+            ]
+
+            self.assertEqual(manifest["alignmentModel"]["alignedSlices"], 2)
+            self.assertEqual(manifest["alignmentModel"]["skippedSlices"], [])
+            self.assertEqual(
+                (tmp_path / "slice_2_first_frame.pdb").read_text(encoding="utf-8"),
+                "".join(
+                    _atom_line(index, "CA", "A", index, 2.0, x, y, z)
+                    for index, (x, y, z) in enumerate(mobile, start=1)
+                )
+                + "END\n",
+            )
+            for observed, expected in zip(aligned, reference):
+                for observed_value, expected_value in zip(observed, expected):
+                    self.assertAlmostEqual(observed_value, expected_value, places=3)
+
+    def test_default_rotation_uses_aligned_motion_envelope_principal_axis(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            coordinates = [(0.0, 0.0, 0.0), (2.0, 2.0, 0.2), (4.0, 4.0, -0.1), (6.0, 6.0, 0.1)]
+            lines = [
+                _atom_line(index, "CA", "A", index, 1.0, x, y, z)
+                for index, (x, y, z) in enumerate(coordinates, start=1)
+            ]
+            (tmp_path / "slice_1_first_frame.pdb").write_text("".join(lines) + "END\n", encoding="utf-8")
+
+            manifest = build_molstar_manifest(tmp_path)
+            rotation = manifest["rotationModel"]
+            matrix = rotation["defaultRotationMatrix"]
+            diagonal = (1.0, 1.0, 0.0)
+            transformed = [sum(matrix[row][column] * diagonal[column] for column in range(3)) for row in range(3)]
+
+            self.assertEqual(rotation["defaultRotationSource"], "principal-axis orientation")
+            self.assertEqual(rotation["orientationSelection"], "alpha carbons across aligned slices")
+            self.assertGreater(transformed[0], 1.4)
+            self.assertAlmostEqual(transformed[1], 0.0, places=2)
+            self.assertAlmostEqual(transformed[2], 0.0, places=2)
+
     def test_run_flipbook_molstar_writes_manifest_and_notebook_html(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp_path = Path(tmpdir)


### PR DESCRIPTION
## Summary

- rigidly fit each displayed slice to slice 1 using common alpha-carbon coordinates
- choose a shared principal-axis starting orientation from the complete aligned motion envelope
- preserve the existing manual rotation controls and leave source PDB slices unchanged
- record alignment and orientation details in the Molstar manifest
- make the no-installation Colab demo the first and most prominent README action

## Why

RMSX slice structures can retain different rigid-body orientations. Molstar previously applied only a fixed 90-degree starting rotation, which could make a flipbook look misaligned or awkward even though the underlying motion data were correct. This makes the browser and notebook view start from a consistent, useful orientation while keeping the transformation strictly inside the interactive report.

## Validation

- `python3 -m unittest discover -s tests -p 'test_*.py'` (38 tests pass)
- built the package wheel with `python3 -m pip wheel . --no-deps`
- visually checked the bundled ubiquitin and protease flipbooks in Molstar
- visually checked the updated README on the GitHub branch
- added coverage for rigid fitting, principal-axis orientation, and preservation of on-disk PDB slices